### PR TITLE
Remove style-scoped classes

### DIFF
--- a/vaadin-demo-snippet.html
+++ b/vaadin-demo-snippet.html
@@ -115,7 +115,7 @@
           .replace(/window\.addDemoReadyListener\('[^{]+/g, `window.addEventListener('WebComponentsReady', function() `);
 
         // Remove style-scoped classes that are appended when ShadyDOM is enabled
-        snippet = snippet.replace(new RegExp('\\s*' + this.getAttribute('class'), 'g'), '');
+        Array.from(this.classList).forEach(e => snippet = snippet.replace(new RegExp('\\s*' + e, 'g'), ''));
         snippet = snippet.replace(/ class=""/g, '');
 
         // Boolean properties are displayed as checked="", so remove the ="" bit.

--- a/vaadin-demo-snippet.html
+++ b/vaadin-demo-snippet.html
@@ -114,6 +114,10 @@
         let snippet = this.$.marked.unindent(template.innerHTML)
           .replace(/window\.addDemoReadyListener\('[^{]+/g, `window.addEventListener('WebComponentsReady', function() `);
 
+        // Remove style-scoped classes that are appended when ShadyDOM is enabled
+        snippet = snippet.replace(new RegExp('\\s*' + this.getAttribute('class'), 'g'), '');
+        snippet = snippet.replace(/ class=""/g, '');
+
         // Boolean properties are displayed as checked="", so remove the ="" bit.
         snippet = snippet.replace(/=""/g, '');
         this._markdown = '```html\n' + snippet + '\n' + '```';


### PR DESCRIPTION
Connected to #5 

Remove style-scoped classes that are appended when ShadyDOM is enabled

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-demo-helpers/8)
<!-- Reviewable:end -->
