### PR TITLE
Run callbacks for new demo instances

### DIFF
--- a/vaadin-demo-ready-event-emitter.html
+++ b/vaadin-demo-ready-event-emitter.html
@@ -3,14 +3,11 @@
 
   window.addDemoReadyListener = function (demoId, callback) {
     let listenerFunction = function (evt) {
-      // Dont run callback functions if the demo was already run
-      if (emitted.indexOf(demoId) < 0) {
-        let demo = evt.detail.host.root.querySelector(demoId).root;
-        if (demo) {
-          window.removeEventListener('VaadinDemoReady', listenerFunction);
-          emitted.push(demoId)
-          callback(demo);
-        }
+      let demo = evt.detail.host.root.querySelector(demoId).root;
+      if (demo) {
+        window.removeEventListener('VaadinDemoReady', listenerFunction);
+        emitted.push(demoId)
+        callback(demo);
       }
     };
 


### PR DESCRIPTION
Fixes #12 
Fixes vaadin/vaadin-combo-box#584

Since the demo frame creates new instances of individual demo pages on navigation, the callback should be run for every new instance or the demo doesn't work properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-demo-helpers/16)
<!-- Reviewable:end -->
