### PR TITLE
Remove no longer needed eval (original issue fixed in polyfill)

### DIFF
--- a/vaadin-demo-snippet.html
+++ b/vaadin-demo-snippet.html
@@ -252,12 +252,6 @@
 
         let dom = this.getRootNode().host._stampTemplate(template);
         this.$.demo.appendChild(dom);
-
-        // FIXME: change this workaround by a better approach
-        // In all browsers except chrome, script tags are not executed when stamped
-        if (!/Chrome/.test(window.navigator.userAgent) || window.MSStream) {
-          Array.from(this.$.demo.querySelectorAll('script')).forEach(e => eval(e.textContent));
-        }
       }
 
       _copyToClipboard() {


### PR DESCRIPTION
Connected to vaadin/vaadin-date-picker#496
Fixes vaadin/vaadin-date-picker#496
Fixes vaadin/vaadin-combo-box#596

Now that the webcomponents/template#26 is merged and released as part of the `webcomponentsjs` 1.0.21 we should drop this evil workaround causing weird bugs in demos (event listeners being added twice).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-demo-helpers/18)
<!-- Reviewable:end -->
