### PR TITLE
Update development mode detection

### DIFF
--- a/vaadin-component-demo.html
+++ b/vaadin-component-demo.html
@@ -162,7 +162,7 @@
 
       _isDevMode(baseHref) {
         // FIXME: find a better way to detect when demo is running in flow
-        return /^cdn|appspot\.com$/.test(location.hostname) || /\/components\//.test(baseHref);
+        return /^cdn|appspot\.com$/.test(location.hostname) || /\/components\/[a-z\-]+\/demo/.test(baseHref);
       }
 
       // Use hash fragment for navigation if we are using polyserve URL


### PR DESCRIPTION
Fixes #24 

Actually, the only difference in `baseHref` is now `demo` for the local or CDN, and `html-examples` for vaadin.com

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-demo-helpers/25)
<!-- Reviewable:end -->
