### PR TITLE
cherry-pick the iframe-renderer feature into the vaadin-com branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bower_components
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# A set of helper elements for showing Vaadin Element demos
+# A set of helper elements for showing Vaadin component demos

--- a/bower.json
+++ b/bower.json
@@ -13,8 +13,5 @@
   "devDependencies": {
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
     "web-component-tester": "Polymer/web-component-tester#^6.0.0"
-  },
-  "resolutions": {
-    "polymer": "^2.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "polymer": "Polymer/polymer#^2.0.0",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.1.1",
     "marked-element": "PolymerElements/marked-element#^2.2.0",
     "prism-element": "PolymerElements/prism-highlighter#^2.0.1",
     "app-route": "PolymerElements/app-route#^2.0.2",
@@ -11,8 +12,7 @@
   },
   "devDependencies": {
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
-    "web-component-tester": "Polymer/web-component-tester#^6.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
+    "web-component-tester": "Polymer/web-component-tester#^6.0.0"
   },
   "resolutions": {
     "polymer": "^2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vaadin-demo-helpers",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaadin-demo-helpers",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Helper components for showing Vaadin Element demos",
   "main": "vaadin-component-demo.html",
   "repository": "vaadin/vaadin-demo-helpers",

--- a/vaadin-component-demo.html
+++ b/vaadin-component-demo.html
@@ -110,7 +110,7 @@
 
     <nav id="nav">
       <ul>
-        <template is="dom-repeat" items="[[_demoConfig.pages]]" as="page">
+        <template is="dom-repeat" items="[[_demoConfig.pages]]" as="page" id="navigationRepeat">
           <li><a href$="[[linkBase]][[page.url]]" name$="[[page.url]]">[[page.name]]</a></li>
         </template>
       </ul>
@@ -156,6 +156,10 @@
           routePattern: {
             type: String,
             computed: '_getRoutePattern(devMode, linkBase)'
+          },
+          navigationRepeatReady: {
+            type: Boolean,
+            value: false
           }
         };
       }
@@ -179,24 +183,28 @@
         if (!this.srcBaseHref) {
           this.srcBaseHref = this.baseHref;
         }
+        this.$.navigationRepeat.addEventListener('dom-change', () => {
+          this.navigationRepeatReady = true;
+        });
       }
 
       static get observers() {
         return [
-          '_routePageChanged(routeData.page)',
+          '_routePageChanged(routeData.page, navigationRepeatReady)',
         ];
       }
 
-      _routePageChanged(page) {
-        if (!page || this.selectedPage === page) return;
+      _routePageChanged(page, navigationRepeatReady) {
+        if (!page) return;
 
         this.selectedPage = page;
-        setTimeout(() => {
+
+        if (navigationRepeatReady) {
           Array.from(this.$.nav.querySelectorAll('a')).forEach(e => e.removeAttribute('active'));
-          let activeLink = this.$.nav.querySelector('a[name="' + page + '"]');
+          const activeLink = this.$.nav.querySelector('a[name="' + page + '"]');
           activeLink.setAttribute('active', '');
           activeLink.scrollIntoView();
-        }, 100);
+        }
       }
 
       _configChanged() {

--- a/vaadin-component-demo.html
+++ b/vaadin-component-demo.html
@@ -166,7 +166,7 @@
 
       _isDevMode(baseHref) {
         // FIXME: find a better way to detect when demo is running in flow
-        return /^cdn|appspot\.com$/.test(location.hostname) || /\/components\/[a-z\-]+\/demo/.test(baseHref);
+        return /^cdn|github\.io|appspot\.com$/.test(location.hostname) || /\/components\/[a-z\-]+\/demo/.test(baseHref);
       }
 
       // Use hash fragment for navigation if we are using polyserve URL

--- a/vaadin-demo-iframe-renderer-outlet.html
+++ b/vaadin-demo-iframe-renderer-outlet.html
@@ -59,40 +59,41 @@
       if (event.origin === window.origin) {
         switch (event.data.type) {
           case 'set-template':
-          this.__webComponentsReady.then(() => {
+            this.__webComponentsReady.then(() => {
               this.setInnerHtmlWithScripts(event.data.html);
               this.history = ['/'];
-              this.historyIdx = 0;
-              this.historyIdxUpdated = true;
-              window.history.pushState(null, '', '/');
-              window.dispatchEvent(new PopStateEvent('popstate', {state: null}));
+                this._activateHistoryEntry(0);
             });
             break;
           case 'set-url':
-            this.historyIdx += 1;
-            this.historyIdxUpdated = true;
-            this.history.splice(this.historyIdx, this.history.length - this.historyIdx, event.data.url);
-            window.history.pushState(null, '', event.data.url);
-            window.dispatchEvent(new PopStateEvent('popstate', {state: null}));
+            this.history[this.historyIdx + 1] = event.data.url;
+            this.history.length = this.historyIdx + 2; // truncate the array
+            this._activateHistoryEntry(this.historyIdx + 1);
             break;
           case 'go-back':
+            // do not use window.history.back() here because that could affect other iframes
             if (this.historyIdx > 0) {
-              this.historyIdx -= 1;
-              this.historyIdxUpdated = true;
+              this._activateHistoryEntry(this.historyIdx - 1);
             }
-            window.history.back();
             break;
           case 'go-forward':
+            // do not use window.history.forward() here because that could affect other iframes
             if (this.historyIdx < this.history.length - 1) {
-              this.historyIdx += 1;
-              this.historyIdxUpdated = true;
+              this._activateHistoryEntry(this.historyIdx + 1);
             }
-            window.history.forward();
             break;
           default:
-            console.log(`unknown message type: ${event.data.type}`);
+            // no-op
+            // console.log(`unknown message type: ${event.data.type}`);
         }
       }
+    }
+
+    _activateHistoryEntry(historyIdx) {
+      this.historyIdx = historyIdx;
+      this.historyIdxUpdated = true;
+      window.history.pushState(null, document.title, this.history[historyIdx]);
+      window.dispatchEvent(new PopStateEvent('popstate'));
     }
 
     _onWindowPopstate(event) {
@@ -100,7 +101,8 @@
         this.historyIdxUpdated = false;
       } else {
         this.historyIdx += 1;
-        this.history.splice(this.historyIdx, this.history.length - this.historyIdx, window.location.pathname);
+        this.history[this.historyIdx] = window.location.pathname;
+        this.history.length = this.historyIdx + 1; // truncate the array
       }
       this._postPopstateMessage();
     }

--- a/vaadin-demo-iframe-renderer-outlet.html
+++ b/vaadin-demo-iframe-renderer-outlet.html
@@ -60,6 +60,7 @@
         switch (event.data.type) {
           case 'set-template':
             this.__webComponentsReady.then(() => {
+              this._setDemoComponentsRoot();
               this.setInnerHtmlWithScripts(event.data.html);
               this.history = ['/'];
                 this._activateHistoryEntry(0);
@@ -105,6 +106,12 @@
         this.history.length = this.historyIdx + 1; // truncate the array
       }
       this._postPopstateMessage();
+    }
+
+    _setDemoComponentsRoot() {
+      // store the reference for lazy loading
+      window.Vaadin = window.Vaadin || {};
+      window.Vaadin.demoComponentsRoot = window.frameElement.dataset.demoComponentsRoot;
     }
 
     setInnerHtmlWithScripts(html) {

--- a/vaadin-demo-iframe-renderer-outlet.html
+++ b/vaadin-demo-iframe-renderer-outlet.html
@@ -1,0 +1,85 @@
+<script>
+(()=>{
+  'use strict';
+
+  class VaadinDemoIframeRendererOutlet extends HTMLElement {
+    constructor() {
+      super();
+      this.__windowMessageListener = this._onWindowMessage.bind(this);
+      this.__windowPopstateListener = this._onWindowPopstate.bind(this);
+    }
+
+    connectedCallback() {
+      this.history = [];
+      this.historyIdx = 0;
+      this.historyIdxUpdated = false;
+
+      window.addEventListener('message', this.__windowMessageListener);
+      window.addEventListener('popstate', this.__windowPopstateListener);
+    }
+
+    disconnectedCallback() {
+      window.removeEventListener('message', this.__windowMessageListener);
+      window.removeEventListener('popstate', this.__windowPopstateListener);
+    }
+
+    _onWindowMessage(event) {
+      if (event.origin === window.origin) {
+        switch (event.data.type) {
+          case 'set-template':
+            this.innerHTML = event.data.html;
+            this.history = ['/'];
+            this.historyIdx = 0;
+            this.historyIdxUpdated = true;
+            window.history.pushState(null, '', '/');
+            window.dispatchEvent(new PopStateEvent('popstate', {state: null}));
+            break;
+          case 'set-url':
+            this.historyIdx += 1;
+            this.historyIdxUpdated = true;
+            this.history.splice(this.historyIdx, this.history.length - this.historyIdx, event.data.url);
+            window.history.pushState(null, '', event.data.url);
+            window.dispatchEvent(new PopStateEvent('popstate', {state: null}));
+            break;
+          case 'go-back':
+            if (this.historyIdx > 0) {
+              this.historyIdx -= 1;
+              this.historyIdxUpdated = true;
+            }
+            window.history.back();
+            break;
+          case 'go-forward':
+            if (this.historyIdx < this.history.length - 1) {
+              this.historyIdx += 1;
+              this.historyIdxUpdated = true;
+            }
+            window.history.forward();
+            break;
+          default:
+            console.log(`unknown message type: ${event.data.type}`);
+        }
+      }
+    }
+
+    _onWindowPopstate(event) {
+      if (this.historyIdxUpdated) {
+        this.historyIdxUpdated = false;
+      } else {
+        this.historyIdx += 1;
+        this.history.splice(this.historyIdx, this.history.length - this.historyIdx, window.location.pathname);
+      }
+      window.parent.postMessage({
+        type: 'iframe-popstate',
+        instance: window.frameElement.instance,
+        detail: {
+          pathname: window.location.pathname,
+          hasBack: this.historyIdx > 0,
+          hasForward: this.historyIdx < this.history.length - 1
+        }
+      }, window.origin);
+    }
+  }
+
+  window.customElements.define('vaadin-demo-iframe-renderer-outlet', VaadinDemoIframeRendererOutlet);
+})();
+</script>

--- a/vaadin-demo-iframe-renderer-outlet.html
+++ b/vaadin-demo-iframe-renderer-outlet.html
@@ -10,17 +10,36 @@
     }
 
     connectedCallback() {
-      this.history = [];
+      this.history = [window.location.pathname];
       this.historyIdx = 0;
       this.historyIdxUpdated = false;
 
       window.addEventListener('message', this.__windowMessageListener);
       window.addEventListener('popstate', this.__windowPopstateListener);
+
+      // notify the parent that the iframe renderer is ready
+      this._postPopstateMessage();
     }
 
     disconnectedCallback() {
       window.removeEventListener('message', this.__windowMessageListener);
       window.removeEventListener('popstate', this.__windowPopstateListener);
+    }
+
+    _postMessage(type, detail) {
+      window.parent.postMessage({
+        type: type,
+        id: window.frameElement.name,
+        detail: detail
+      }, window.origin);
+    }
+
+    _postPopstateMessage() {
+      this._postMessage('iframe-popstate', {
+        pathname: window.location.pathname,
+        hasBack: this.historyIdx > 0,
+        hasForward: this.historyIdx < this.history.length - 1
+      });
     }
 
     _onWindowMessage(event) {
@@ -68,15 +87,7 @@
         this.historyIdx += 1;
         this.history.splice(this.historyIdx, this.history.length - this.historyIdx, window.location.pathname);
       }
-      window.parent.postMessage({
-        type: 'iframe-popstate',
-        id: window.frameElement.name,
-        detail: {
-          pathname: window.location.pathname,
-          hasBack: this.historyIdx > 0,
-          hasForward: this.historyIdx < this.history.length - 1
-        }
-      }, window.origin);
+      this._postPopstateMessage();
     }
   }
 

--- a/vaadin-demo-iframe-renderer-outlet.html
+++ b/vaadin-demo-iframe-renderer-outlet.html
@@ -7,6 +7,19 @@
       super();
       this.__windowMessageListener = this._onWindowMessage.bind(this);
       this.__windowPopstateListener = this._onWindowPopstate.bind(this);
+
+      this.__webComponentsReady = new Promise((resolve, reject) => {
+        if (window.WebComponents.ready) {
+          resolve();
+        } else {
+          function onWebComponentsReady() {
+            document.removeEventListener('WebComponentsReady', onWebComponentsReady);
+            resolve();
+          }
+
+          document.addEventListener('WebComponentsReady', onWebComponentsReady);
+        }
+      });
     }
 
     connectedCallback() {
@@ -46,12 +59,14 @@
       if (event.origin === window.origin) {
         switch (event.data.type) {
           case 'set-template':
-            this.setInnerHtmlWithScripts(event.data.html);
-            this.history = ['/'];
-            this.historyIdx = 0;
-            this.historyIdxUpdated = true;
-            window.history.pushState(null, '', '/');
-            window.dispatchEvent(new PopStateEvent('popstate', {state: null}));
+          this.__webComponentsReady.then(() => {
+              this.setInnerHtmlWithScripts(event.data.html);
+              this.history = ['/'];
+              this.historyIdx = 0;
+              this.historyIdxUpdated = true;
+              window.history.pushState(null, '', '/');
+              window.dispatchEvent(new PopStateEvent('popstate', {state: null}));
+            });
             break;
           case 'set-url':
             this.historyIdx += 1;

--- a/vaadin-demo-iframe-renderer-outlet.html
+++ b/vaadin-demo-iframe-renderer-outlet.html
@@ -111,7 +111,8 @@
     _setDemoComponentsRoot() {
       // store the reference for lazy loading
       window.Vaadin = window.Vaadin || {};
-      window.Vaadin.demoComponentsRoot = window.frameElement.dataset.demoComponentsRoot;
+      Vaadin.Demo = Vaadin.Demo || {};
+      Vaadin.Demo.componentsRoot = window.frameElement.dataset.demoComponentsRoot;
     }
 
     setInnerHtmlWithScripts(html) {

--- a/vaadin-demo-iframe-renderer-outlet.html
+++ b/vaadin-demo-iframe-renderer-outlet.html
@@ -70,7 +70,7 @@
       }
       window.parent.postMessage({
         type: 'iframe-popstate',
-        instance: window.frameElement.instance,
+        id: window.frameElement.name,
         detail: {
           pathname: window.location.pathname,
           hasBack: this.historyIdx > 0,

--- a/vaadin-demo-iframe-renderer-outlet.html
+++ b/vaadin-demo-iframe-renderer-outlet.html
@@ -46,7 +46,7 @@
       if (event.origin === window.origin) {
         switch (event.data.type) {
           case 'set-template':
-            this.innerHTML = event.data.html;
+            this.setInnerHtmlWithScripts(event.data.html);
             this.history = ['/'];
             this.historyIdx = 0;
             this.historyIdxUpdated = true;
@@ -88,6 +88,22 @@
         this.history.splice(this.historyIdx, this.history.length - this.historyIdx, window.location.pathname);
       }
       this._postPopstateMessage();
+    }
+
+    setInnerHtmlWithScripts(html) {
+      this.innerHTML = html;
+      const scripts = this.querySelectorAll('script');
+      for (let i = 0; i < scripts.length; i += 1) {
+        const script = document.createElement('script');
+        ['type', 'async', 'defer', 'noModule', 'text'].forEach(
+          prop => script[prop] = scripts[i][prop]
+        );
+        if (scripts[i].src) {
+          script.src = scripts[i].src;
+        }
+        scripts[i].parentNode.insertBefore(script, scripts[i]);
+        scripts[i].parentNode.removeChild(scripts[i]);
+      }
     }
   }
 

--- a/vaadin-demo-iframe-renderer.html
+++ b/vaadin-demo-iframe-renderer.html
@@ -39,7 +39,7 @@
       <input class="url" value="[[url]]" on-change="_onUrlEdited">
     </div>
     
-    <iframe id="demo" src="[[src]]" instance="[[_instance]]"
+    <iframe id="demo" name="[[id]]" src="[[src]]"
             on-load="_onIframeLoad" on-error="_onIframeError">
     </iframe>
   </template>
@@ -55,6 +55,12 @@
 
       static get properties() {
         return {
+          id: {
+            type: String,
+            value: () => {
+              return `vaadin-demo-iframe-${instanceIndex++}`;
+            }
+          },
           src: {
             type: String,
             value: 'about:blank'
@@ -64,14 +70,12 @@
             value: '/'
           },
           hasBack: Boolean,
-          hasForward: Boolean,
-          _instance: String
+          hasForward: Boolean
         };
       }
 
       constructor() {
         super();
-        this._instance = `${instanceIndex++}`;
         this.__windowMessageListener = this._onWindowMessage.bind(this);
         this.__iframeLoaded = new Promise((resolve, reject) => {
           this.__resolveIframeLoaded = resolve;
@@ -122,7 +126,7 @@
       _onWindowMessage(event) {
         if (event.origin === window.origin &&
             event.data.type === 'iframe-popstate' &&
-            event.data.instance === this._instance)
+            event.data.id === this.id)
         {
           const detail = event.data.detail;
           this.url = detail.pathname;

--- a/vaadin-demo-iframe-renderer.html
+++ b/vaadin-demo-iframe-renderer.html
@@ -39,9 +39,7 @@
       <input class="url" value="[[url]]" on-change="_onUrlEdited">
     </div>
     
-    <iframe id="demo" name="[[id]]" src="[[src]]"
-            on-load="_onIframeLoad" on-error="_onIframeError">
-    </iframe>
+    <iframe id="demo" name="[[id]]" src="[[src]]"></iframe>
   </template>
 
   <script>
@@ -77,9 +75,9 @@
       constructor() {
         super();
         this.__windowMessageListener = this._onWindowMessage.bind(this);
-        this.__iframeLoaded = new Promise((resolve, reject) => {
-          this.__resolveIframeLoaded = resolve;
-          this.__rejectIframeLoaded = reject;
+        this.__iframeReady = new Promise((resolve, reject) => {
+          this.__resolveIframeReady = resolve;
+          this.__rejectIframeReady = reject;
         });
       }
 
@@ -107,16 +105,8 @@
           });
       }
 
-      _onIframeLoad() {
-        this.__resolveIframeLoaded(this.$.demo);
-      }
-
-      _onIframeError(error) {
-        this.__rejectIframeLoaded(error);
-      }
-
       _postIframeMessage(message) {
-        this.__iframeLoaded.then((iframe) => {
+        this.__iframeReady.then((iframe) => {
           iframe.contentWindow.postMessage(message, window.origin);
         }).catch((error) => {
           console.log(`demo iframe failed to load: ${error}`)
@@ -128,6 +118,8 @@
             event.data.type === 'iframe-popstate' &&
             event.data.id === this.id)
         {
+          this.__resolveIframeReady(this.$.demo);
+
           const detail = event.data.detail;
           this.url = detail.pathname;
           this.hasBack = detail.hasBack;

--- a/vaadin-demo-iframe-renderer.html
+++ b/vaadin-demo-iframe-renderer.html
@@ -1,0 +1,159 @@
+<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="vaadin-light-dom-helper.html">
+
+<dom-module id="vaadin-demo-iframe-renderer">
+  <template>
+    <style>
+      :host {
+        display: block;
+      }
+
+      .toolbar {
+        display: flex;
+        background-color: rgba(0, 0, 0, 0.02);
+        border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+        padding: 0.6em;
+      }
+
+      .back,
+      .forward,
+      .url {
+        flex: 0 0 auto;
+        font-size: 16px;
+      }
+
+      .url {
+        flex-grow: 1;
+      }
+
+      #demo {
+        display: block;
+        width: 100%;
+        border: 0;
+      }
+    </style>
+
+    <div class="toolbar">
+      <button class="back" disabled=[[!hasBack]] on-click="_onBackClicked">&lt;</button>
+      <button class="forward" disabled=[[!hasForward]] on-click="_onForwardClicked">&gt;</button>
+      <input class="url" value="[[url]]" on-change="_onUrlEdited">
+    </div>
+    
+    <iframe id="demo" src="[[src]]" instance="[[_instance]]"
+            on-load="_onIframeLoad" on-error="_onIframeError">
+    </iframe>
+  </template>
+
+  <script>
+  (()=>{
+    'use strict';
+    let instanceIndex = 0;
+    class VaadinDemoIframeRenderer extends Polymer.Element {
+      static get is() {
+        return 'vaadin-demo-iframe-renderer';
+      }
+
+      static get properties() {
+        return {
+          src: {
+            type: String,
+            value: 'about:blank'
+          },
+          url: {
+            type: String,
+            value: '/'
+          },
+          hasBack: Boolean,
+          hasForward: Boolean,
+          _instance: String
+        };
+      }
+
+      constructor() {
+        super();
+        this._instance = `${instanceIndex++}`;
+        this.__windowMessageListener = this._onWindowMessage.bind(this);
+        this.__iframeLoaded = new Promise((resolve, reject) => {
+          this.__resolveIframeLoaded = resolve;
+          this.__rejectIframeLoaded = reject;
+        });
+      }
+
+      connectedCallback() {
+        super.connectedCallback();
+        window.addEventListener('message', this.__windowMessageListener);
+      }
+
+      disconnectedCallback() {
+        window.removeEventListener('message', this.__windowMessageListener);
+        super.disconnectedCallback();
+      }
+
+      ready() {
+        super.ready();
+        Vaadin.LightDomHelper.querySelectorAsync('slot', this)
+          .then(slot => {
+            return Vaadin.LightDomHelper.querySlotContentAsync('template', slot)
+          })
+          .then(template => {
+            this._showDemo(template);
+          })
+          .catch(error => {
+            throw new Error('vaadin-demo-iframe-renderer requires a <template> child');
+          });
+      }
+
+      _onIframeLoad() {
+        this.__resolveIframeLoaded(this.$.demo);
+      }
+
+      _onIframeError(error) {
+        this.__rejectIframeLoaded(error);
+      }
+
+      _postIframeMessage(message) {
+        this.__iframeLoaded.then((iframe) => {
+          iframe.contentWindow.postMessage(message, window.origin);
+        }).catch((error) => {
+          console.log(`demo iframe failed to load: ${error}`)
+        });
+      }
+
+      _onWindowMessage(event) {
+        if (event.origin === window.origin &&
+            event.data.type === 'iframe-popstate' &&
+            event.data.instance === this._instance)
+        {
+          const detail = event.data.detail;
+          this.url = detail.pathname;
+          this.hasBack = detail.hasBack;
+          this.hasForward = detail.hasForward;
+        }
+      }
+
+      _onBackClicked() {
+        this._postIframeMessage({type: 'go-back'});
+      }
+
+      _onForwardClicked() {
+        this._postIframeMessage({type: 'go-forward'});
+      }
+
+      _onUrlEdited(event) {
+        let url = (event.target.value || '').trim();
+        if (url === '') {
+          url = '/';
+        }
+        event.target.value = url;
+        this._postIframeMessage({type: 'set-url', url: url});
+      }
+
+      _showDemo(template) {
+        this._postIframeMessage({type: 'set-template', html: template.innerHTML});
+      }
+    }
+    customElements.define(VaadinDemoIframeRenderer.is, VaadinDemoIframeRenderer);
+  })();
+  </script>
+
+</dom-module>

--- a/vaadin-demo-iframe-renderer.html
+++ b/vaadin-demo-iframe-renderer.html
@@ -10,20 +10,64 @@
 
       .toolbar {
         display: flex;
-        background-color: rgba(0, 0, 0, 0.02);
-        border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-        padding: 0.6em;
+        background-color: #f2f3f7;
+        border-bottom: 1px solid #ced0dd;
+        padding: 0.8rem 1rem .8rem .8rem;
       }
 
-      .back,
-      .forward,
-      .url {
+      .back, .forward, .url {
         flex: 0 0 auto;
-        font-size: 16px;
+        height: 30px;
+        box-sizing: border-box;
+      }
+
+      .back, .forward {
+        line-height: 33px;
+        background: #f2f3f7;
+        border: none;
+        width: 30px;
+        transition: all ease-in .1s;
+      }
+
+      .back:hover,
+      .forward:hover {
+        background:#dfe1ea; 
+        border-radius: 3px;
+      }
+
+      .back[disabled], .forward[disabled] {
+        opacity: .5;
+      }
+
+      .back[disabled]:hover,
+      .forward[disabled]:hover {
+        background: none;
+      }
+
+      .back svg,
+      .forward svg{
+        width: 14px;
+        height: auto;
+        
       }
 
       .url {
         flex-grow: 1;
+        border-radius: 3px;
+        outline: none;
+        box-shadow: none;
+        border: 1px solid #ced0dd;
+        padding: 5px 10px;
+        line-height: 30px;
+        font-family: 'Helvetica';
+        font-size: 14px;
+        margin-left: 10px;
+        transition: all ease-in .1s;
+      }
+
+      .url:focus {
+        border: 1px solid #9ec5ef;
+        box-shadow: 0 2px 8px 0 rgba(0,0,0,.08);
       }
 
       #demo {
@@ -34,8 +78,21 @@
     </style>
 
     <div class="toolbar">
-      <button class="back" disabled=[[!hasBack]] on-click="_onBackClicked">&lt;</button>
-      <button class="forward" disabled=[[!hasForward]] on-click="_onForwardClicked">&gt;</button>
+      <button class="back" disabled=[[!hasBack]] on-click="_onBackClicked">
+        <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+          <title>icon-arrow-left</title>
+          <polyline points="20.6 8 5.62 24.1 20.6 40.2" fill="none" stroke="#686f75" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"/>
+          <line x1="7.53" y1="24.1" x2="42.33" y2="24.1" fill="none" stroke="#686f75" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"/>
+        </svg>
+      
+      </button> 
+      <button class="forward" disabled=[[!hasForward]] on-click="_onForwardClicked">
+        <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+          <title>icon-arrow-right</title>
+          <polyline points="27.35 40.2 42.33 24.1 27.35 8" fill="none" stroke="#686f75" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"/>
+          <line x1="40.42" y1="24.1" x2="5.62" y2="24.1" fill="none" stroke="#686f75" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"/>
+        </svg>
+      </button> 
       <input class="url" value="[[url]]" on-change="_onUrlEdited">
     </div>
     

--- a/vaadin-demo-iframe-renderer.html
+++ b/vaadin-demo-iframe-renderer.html
@@ -29,6 +29,11 @@
         transition: all ease-in .1s;
       }
 
+      .forward {
+        /* give space for the focus outline ring (chrome) */
+        margin-left: 5px;
+      }
+
       .back:hover,
       .forward:hover {
         background:#dfe1ea; 

--- a/vaadin-demo-iframe-renderer.html
+++ b/vaadin-demo-iframe-renderer.html
@@ -36,7 +36,7 @@
 
       .back:hover,
       .forward:hover {
-        background:#dfe1ea; 
+        background:#dfe1ea;
         border-radius: 3px;
       }
 
@@ -53,7 +53,7 @@
       .forward svg{
         width: 14px;
         height: auto;
-        
+
       }
 
       .url {
@@ -89,19 +89,19 @@
           <polyline points="20.6 8 5.62 24.1 20.6 40.2" fill="none" stroke="#686f75" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"/>
           <line x1="7.53" y1="24.1" x2="42.33" y2="24.1" fill="none" stroke="#686f75" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"/>
         </svg>
-      
-      </button> 
+
+      </button>
       <button class="forward" disabled=[[!hasForward]] on-click="_onForwardClicked">
         <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
           <title>icon-arrow-right</title>
           <polyline points="27.35 40.2 42.33 24.1 27.35 8" fill="none" stroke="#686f75" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"/>
           <line x1="40.42" y1="24.1" x2="5.62" y2="24.1" fill="none" stroke="#686f75" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"/>
         </svg>
-      </button> 
+      </button>
       <input class="url" value="[[url]]" on-change="_onUrlEdited">
     </div>
-    
-    <iframe id="demo" name="[[id]]" src="[[src]]"></iframe>
+
+    <iframe id="demo" name="[[id]]" src="[[src]]" data-demo-components-root$="[[demoComponentsRoot]]"></iframe>
   </template>
 
   <script>
@@ -120,6 +120,9 @@
             value: () => {
               return `vaadin-demo-iframe-${instanceIndex++}`;
             }
+          },
+          demoComponentsRoot: {
+            type: String
           },
           src: {
             type: String,

--- a/vaadin-demo-import.js
+++ b/vaadin-demo-import.js
@@ -1,0 +1,24 @@
+(() => {
+  window.Vaadin = window.Vaadin || {};
+  Vaadin.Demo = Vaadin.Demo || {};
+  Vaadin.Demo.moduleStorage = Vaadin.Demo.moduleStorage || [];
+
+  Vaadin.Demo.import = url => {
+    return new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = url;
+
+      script.onload = () => {
+        document.body.removeChild(script);
+        resolve(Vaadin.Demo.moduleStorage.pop());
+      };
+
+      script.onerror = () => {
+        document.body.removeChild(script);
+        reject(new Error('Failed to load module script with URL ' + url));
+      };
+
+      document.body.appendChild(script);
+    });
+  };
+})();

--- a/vaadin-demo-shadow-dom-renderer.html
+++ b/vaadin-demo-shadow-dom-renderer.html
@@ -1,0 +1,53 @@
+<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="vaadin-light-dom-helper.html">
+
+<dom-module id="vaadin-demo-shadow-dom-renderer">
+  <template>
+    <style>
+      :host {
+        display: block;
+        padding: 1.5em;
+      }
+    </style>
+  </template>
+
+  <script>
+  (()=>{
+    'use strict';
+    let instanceIndex = 0;
+    class VaadinDemoShadowDomRenderer extends Polymer.Element {
+      static get is() {
+        return 'vaadin-demo-shadow-dom-renderer';
+      }
+
+      static get properties() {
+        return {
+        };
+      }
+
+      ready() {
+        super.ready();
+        Vaadin.LightDomHelper.querySelectorAsync('slot', this)
+          .then(slot => {
+            return Vaadin.LightDomHelper.querySlotContentAsync('template', slot)
+          })
+          .then(template => {
+            this._showDemo(template);
+          })
+          .catch(error => {
+            throw new Error('vaadin-demo-iframe-renderer requires a <template> child');
+          });
+      }
+
+      _showDemo(template) {
+        const templateId = 'vaadin-demo-shadow-dom-renderer-' + instanceIndex++;
+        window.ShadyCSS.prepareTemplate(template, templateId);
+        let dom = this.getRootNode().host._stampTemplate(template);
+        this.shadowRoot.appendChild(dom);
+      }
+    }
+    customElements.define(VaadinDemoShadowDomRenderer.is, VaadinDemoShadowDomRenderer);
+  })();
+  </script>
+
+</dom-module>

--- a/vaadin-demo-shadow-dom-renderer.html
+++ b/vaadin-demo-shadow-dom-renderer.html
@@ -22,6 +22,12 @@
 
       static get properties() {
         return {
+          id: {
+            type: String,
+            value: () => {
+              return `vaadin-demo-shadow-dom-${instanceIndex++}`;
+            }
+          },
         };
       }
 
@@ -40,8 +46,7 @@
       }
 
       _showDemo(template) {
-        const templateId = 'vaadin-demo-shadow-dom-renderer-' + instanceIndex++;
-        window.ShadyCSS.prepareTemplate(template, templateId);
+        window.ShadyCSS.prepareTemplate(template, this.id);
         let dom = this.getRootNode().host._stampTemplate(template);
         this.shadowRoot.appendChild(dom);
       }

--- a/vaadin-demo-snippet.html
+++ b/vaadin-demo-snippet.html
@@ -1,8 +1,12 @@
 <link rel="import" href="../polymer/polymer-element.html">
-<link rel="import" href="vaadin-demo-ready-event-emitter.html">
 <link rel="import" href="../polymer/lib/mixins/gesture-event-listeners.html">
 <link rel="import" href="../marked-element/marked-element.html">
 <link rel="import" href="../prism-element/prism-highlighter.html">
+
+<link rel="import" href="vaadin-demo-ready-event-emitter.html">
+<link rel="import" href="vaadin-light-dom-helper.html">
+<link rel="import" href="vaadin-demo-shadow-dom-renderer.html">
+<link rel="import" href="vaadin-demo-iframe-renderer.html">
 
 <dom-module id="vaadin-demo-snippet">
   <template>
@@ -20,7 +24,6 @@
         display: block;
         border-bottom: 1px solid rgba(0, 0, 0, 0.1);
         margin: 0;
-        padding: 1.5em;
         @apply --demo-snippet-demo;
       }
 
@@ -72,6 +75,16 @@
     <prism-highlighter></prism-highlighter>
 
     <div id="demo">
+      <template is="dom-if" if="[[_isIframe]]" restamp>
+        <vaadin-demo-iframe-renderer src="[[iframeSrc]]">
+          <slot></slot>
+        </vaadin-demo-iframe-renderer>
+      </template>
+      <template is="dom-if" if="[[!_isIframe]]" restamp>
+        <vaadin-demo-shadow-dom-renderer>
+          <slot></slot>
+        </vaadin-demo-shadow-dom-renderer>
+      </template>
     </div>
 
     <div class="code-container">
@@ -83,8 +96,8 @@
   </template>
 
   <script>
+  (()=>{
     'use strict';
-    let instanceIndex = 0;
     class VaadinDemoSnippet extends Polymer.GestureEventListeners(Polymer.Element) {
       static get is() {
         return 'vaadin-demo-snippet';
@@ -92,30 +105,32 @@
 
       static get properties() {
         return {
+          iframeSrc: String,
+          _isIframe: {
+            type: Boolean,
+            value: false,
+            computed: '_computeIsIframe(iframeSrc)'
+          },
           _markdown: String
         };
       }
 
       ready() {
         super.ready();
-        this._showDemo();
+        Vaadin.LightDomHelper.querySelectorAsync('template', this)
+          .then(template => {
+            this._showDemo(template);
+          })
+          .catch(error => {
+            throw new Error('vaadin-demo-snippet requires a <template> child');
+          })
       }
 
-      _showDemo() {
-        let template = this.querySelector('template');
-        if (!template) {
-          let observer = new MutationObserver(() => {
-            if (this.querySelector('template')) {
-              observer.disconnect();
-              this._showDemo();
-            } else {
-              throw new Error('vaadin-demo-snippet requires a <template> child');
-            }
-          })
-          observer.observe(this, { childList: true });
-          return false;
-        }
+      _computeIsIframe(iframeSrc) {
+        return (typeof iframeSrc === 'string') && iframeSrc.trim() !== '';
+      }
 
+      _showDemo(template) {
         // Hide the use of window.addDemoReadyListener
         let snippet = this.$.marked.unindent(template.innerHTML)
           .replace(/window\.addDemoReadyListener\('[^{]+/g, `window.addEventListener('WebComponentsReady', function() `);
@@ -126,11 +141,7 @@
 
         // Boolean properties are displayed as checked="", so remove the ="" bit.
         snippet = snippet.replace(/=""/g, '');
-        this._markdown = '```html\n' + snippet.trim() + '\n' + '```';
-
-        window.ShadyCSS.prepareTemplate(template, 'vaadin-demo-snippet-' + instanceIndex++);
-        let dom = this.getRootNode().host._stampTemplate(template);
-        this.$.demo.appendChild(dom);
+        this._markdown = '```html\n' + snippet + '\n' + '```';
       }
 
       _onSyntaxHighlight() {
@@ -169,6 +180,7 @@
       }
     }
     customElements.define(VaadinDemoSnippet.is, VaadinDemoSnippet);
+  })();
   </script>
 
 </dom-module>

--- a/vaadin-demo-snippet.html
+++ b/vaadin-demo-snippet.html
@@ -76,7 +76,7 @@
 
     <div id="demo">
       <template is="dom-if" if="[[_isIframe]]" restamp>
-        <vaadin-demo-iframe-renderer src="[[iframeSrc]]" id="[[id]]">
+        <vaadin-demo-iframe-renderer src="[[iframeSrc]]" id="[[id]]" demo-components-root="[[demoComponentsRoot]]">
           <slot></slot>
         </vaadin-demo-iframe-renderer>
       </template>
@@ -113,6 +113,7 @@
             }
           },
           iframeSrc: String,
+          demoComponentsRoot: String,
           _isIframe: {
             type: Boolean,
             value: false,
@@ -126,6 +127,13 @@
         super.ready();
         Vaadin.LightDomHelper.querySelectorAsync('template', this)
           .then(template => {
+            try {
+              const host = this.getRootNode().host.getRootNode().host;
+              // set the root directory for lazy loaded elements in demos
+              this.demoComponentsRoot = `${host.srcBaseHref}/demo-elements`;
+            } catch(e) {
+              console.error('Unable to get the `baseHref` from the <vaadin-component-demo>');
+            }
             this._showDemo(template);
           })
           .catch(error => {

--- a/vaadin-demo-snippet.html
+++ b/vaadin-demo-snippet.html
@@ -151,7 +151,10 @@
           .replace(/window\.addDemoReadyListener\('[^{]+/g, `window.addEventListener('WebComponentsReady', function() `);
 
         // Hide the use of window.Vaadin.demoComponentsRoot
-        snippet = snippet.replace(/`(\${window\.Vaadin\.demoComponentsRoot})(.+)`/gi, `'$2'`);
+        snippet = snippet.replace(/`(\${Vaadin\.Demo\.componentsRoot})(.+)`/gi, `'$2'`);
+
+        // Hide the use of window.__importModule for dynamic imports
+        snippet = snippet.replace(/(Vaadin\.Demo\.import\(')/gi, `import('.`);
 
         // Remove style-scoped classes that are appended when ShadyDOM is enabled
         Array.from(this.classList).forEach(e => snippet = snippet.replace(new RegExp('\\s*' + e, 'g'), ''));

--- a/vaadin-demo-snippet.html
+++ b/vaadin-demo-snippet.html
@@ -76,12 +76,12 @@
 
     <div id="demo">
       <template is="dom-if" if="[[_isIframe]]" restamp>
-        <vaadin-demo-iframe-renderer src="[[iframeSrc]]">
+        <vaadin-demo-iframe-renderer src="[[iframeSrc]]" id="[[id]]">
           <slot></slot>
         </vaadin-demo-iframe-renderer>
       </template>
       <template is="dom-if" if="[[!_isIframe]]" restamp>
-        <vaadin-demo-shadow-dom-renderer>
+        <vaadin-demo-shadow-dom-renderer id="[[id]]">
           <slot></slot>
         </vaadin-demo-shadow-dom-renderer>
       </template>
@@ -98,6 +98,7 @@
   <script>
   (()=>{
     'use strict';
+    let instanceIndex = 0;
     class VaadinDemoSnippet extends Polymer.GestureEventListeners(Polymer.Element) {
       static get is() {
         return 'vaadin-demo-snippet';
@@ -105,6 +106,12 @@
 
       static get properties() {
         return {
+          id: {
+            type: String,
+            value: () => {
+              return `vaadin-demo-snippet-${instanceIndex++}`;
+            }
+          },
           iframeSrc: String,
           _isIframe: {
             type: Boolean,

--- a/vaadin-demo-snippet.html
+++ b/vaadin-demo-snippet.html
@@ -150,6 +150,9 @@
         let snippet = this.$.marked.unindent(template.innerHTML)
           .replace(/window\.addDemoReadyListener\('[^{]+/g, `window.addEventListener('WebComponentsReady', function() `);
 
+        // Hide the use of window.Vaadin.demoComponentsRoot
+        snippet = snippet.replace(/`(\${window\.Vaadin\.demoComponentsRoot})(.+)`/gi, `'$2'`);
+
         // Remove style-scoped classes that are appended when ShadyDOM is enabled
         Array.from(this.classList).forEach(e => snippet = snippet.replace(new RegExp('\\s*' + e, 'g'), ''));
         snippet = snippet.replace(/ class=""/g, '');

--- a/vaadin-light-dom-helper.html
+++ b/vaadin-light-dom-helper.html
@@ -1,0 +1,68 @@
+<link rel="import" href="../polymer/lib/utils/flattened-nodes-observer.html">
+
+<script>
+  (()=>{
+    'use strict';
+    window.Vaadin = window.Vaadin || {};
+
+    Vaadin.LightDomHelper = {
+      querySelectorAsync(selector, context) {
+        if (!context) {
+          context = document;
+        }
+        return new Promise((resolve, reject) => {
+          let element = context.querySelector(selector);
+          if (element) {
+            resolve(element);
+          } else {
+            let observer = new MutationObserver(() => {
+              let element = context.querySelector(selector);
+              if (element) {
+                observer.disconnect();
+                resolve(element);
+              } else {
+                reject('no element matched the selector even after the first observed mutation');
+              }
+            })
+            observer.observe(context, { childList: true });
+          }
+        });
+      },
+
+      querySlotContentAsync(selector, slot) {
+        const matchesFn = HTMLElement.prototype.matches
+            ? HTMLElement.prototype.matches
+            : HTMLElement.prototype.msMatchesSelector;
+            
+        const query = (slot, selector) => {
+          const assignedNodes = slot.assignedNodes();
+          for (let i = 0; i < assignedNodes.length; i += 1) {
+            const element = assignedNodes[i];
+            if (element instanceof HTMLElement && matchesFn.call(element, selector)) {
+              return element;
+            }
+          }
+
+          return null;
+        };
+
+        return new Promise((resolve, reject) => {
+          let element = query(slot, selector);
+          if (element) {
+            resolve(element);
+          } else {
+            let observer = new Polymer.FlattenedNodesObserver(slot, (info) => {
+              let element = query(slot, selector);
+              if (element) {
+                observer.disconnect();
+                resolve(element);
+              } else {
+                reject('no element matched the selector even after the first observed mutation');
+              }
+            });
+          }
+        });
+      }
+    };
+  })();
+</script>


### PR DESCRIPTION
 - Add an iframe-based snippet renderer that makes URL changes visible
   - extract the existing snippet rendering code from `<vaadin-demo-snippet>` into a separate component: `<vaadin-demo-shadow-dom-renderer>`
   - create an alternative snippet renderer that uses an iframe and has a browser-like address toolbar: `<vaadin-demo-iframe-renderer>`
   - create a counterpart component to `<vaadin-demo-iframe-renderer>`. The counterpart (`<vaadin-demo-iframe-renderer-outlet>`) should be added into an iframe so that the main page can tell the iframe what snippet to render.
   - modify the `<vaadin-demo-snippet>` component to switch between the two renderers based on the new `iframeSrc` property (the default has not changed - it's the Shadow DOM-based renderer).
   - move the utility code shared between the demo-snippet and both renderers into a separate utility file: vaadin-light-dom-helper
   - use the demo snippet IDs as iframe names (they are visible e.g. in the dev tools and that makes debugging easier)
   - ensure that the iframe renderer waits until the outlet is ready before sending messages
     The iframe's load event does not guarantee that the vaadin-demo-iframe-renderer-outlet element is ready to revieve messages. Instead of waiting for that event, rather wait for the first message from the iframe - that certainly means the iframe is ready. The assumption is that the iframe never gets ready before the main document so that the main doc is always ready when the first iframe message arrives.
   - ensure that inline scripts from demo snipptes are actually run when using the iframe renderer 
     If the demo snipper HTML contains `<script>` tags, they are not evaluated when appended to the iframe document by setting the `innerHTML` property. In order for them to get evaluated, they need to be re-created and inserted into the DOM as brand new `HTMLScriptElement`s.
   - defer processing of 'set-template' messages until WebComponentsReady 
     This fixes the issue when the 'set-template' message arrived before all demo iframe HTML imports are ready, and the script in the template content failed because its dependencies were not available (most notably, Vaadin.Router)
 - Add support for relative URLs in demo snippets
   - propagate `baseHref` from the parent window to into the iframe and expose it to the demo snippets as `window.Vaadin.Demo.componentsRoot`
   - do not show to the users the use of `window.Vaadin.Demo.componentsRoot` in snippets code
 - Add support for dynamic imports in demo snippets
   - add a shim to support dynamic imports in demos with `Vaadin.Demo.import`
   - do not show to the users the use of `Vaadin.Demo.import` in snippets code (replace with a 'standard' dynamic import)
 - Add `node_modeules` to .gitignore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-demo-helpers/31)
<!-- Reviewable:end -->
