### PR TITLE
make vaadin-demo-snippet themable (1.x)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,8 @@
     "marked-element": "PolymerElements/marked-element#^2.2.0",
     "prism-element": "PolymerElements/prism-highlighter#^2.0.1",
     "app-route": "PolymerElements/app-route#^2.0.2",
-    "iron-selector": "PolymerElements/iron-selector#^2.0.0"
+    "iron-selector": "PolymerElements/iron-selector#^2.0.0",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.0"
   },
   "devDependencies": {
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",

--- a/vaadin-demo-snippet.html
+++ b/vaadin-demo-snippet.html
@@ -2,8 +2,9 @@
 <link rel="import" href="../polymer/lib/mixins/gesture-event-listeners.html">
 <link rel="import" href="../marked-element/marked-element.html">
 <link rel="import" href="../prism-element/prism-highlighter.html">
+<link rel="import" href="../vaadin-themable-mixin/vaadin-themable-mixin.html">
 
-<dom-module id="prism-theme-default">
+<dom-module id="vaadin-demo-snippet-default-theme">
   <template>
     <style>
     /**
@@ -131,8 +132,8 @@
 
 <dom-module id="vaadin-demo-snippet">
   <template>
-    <style include="prism-theme-default">
-       :host {
+    <style>
+      :host {
         display: block;
 
         background-color: white;
@@ -160,16 +161,15 @@
       }
 
       .code-container .code {
-        padding: 0 2em 1.4em;
+        padding: 1.4em 2em;
         margin: 0;
         overflow: auto;
         max-height: 18.5em;
         @apply --demo-snippet-code;
       }
 
-      .code-container .code>pre {
+      .code-container .code > pre {
         margin: 0;
-        padding: 0;
       }
 
       .code-container button {
@@ -206,7 +206,10 @@
   <script>
     'use strict';
     let instanceIndex = 0;
-    class VaadinDemoSnippet extends Polymer.GestureEventListeners(Polymer.Element) {
+    class VaadinDemoSnippet extends
+      Vaadin.ThemableMixin(
+        Polymer.GestureEventListeners(Polymer.Element)) {
+
       static get is() {
         return 'vaadin-demo-snippet';
       }
@@ -247,7 +250,7 @@
 
         // Boolean properties are displayed as checked="", so remove the ="" bit.
         snippet = snippet.replace(/=""/g, '');
-        this._markdown = '```html\n' + snippet + '\n' + '```';
+        this._markdown = '```html\n' + snippet.trim() + '```';
 
         window.ShadyCSS.prepareTemplate(template, 'vaadin-demo-snippet-' + instanceIndex++);
         let dom = this.getRootNode().host._stampTemplate(template);


### PR DESCRIPTION
Making vaadin-demo-snippet themable allows vaadin.com team to make the customizations they need inside their own code, and removes the need to maintain a separate fork of the demo helpers repo.

(cherry-picked from the 2.x branch: https://github.com/vaadin/vaadin-demo-helpers/pull/32)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-demo-helpers/33)
<!-- Reviewable:end -->
