### PR TITLE
fix the issue when VaadinDemoReady did not work

### DIFF
--- a/vaadin-demo-ready-event-emitter.js
+++ b/vaadin-demo-ready-event-emitter.js
@@ -2,11 +2,12 @@ var emitted = [];
 
 window.addDemoReadyListener = function (demoId, callback) {
   let listenerFunction = function (evt) {
-    let demo = evt.detail.host.root.querySelector(demoId).root;
-    if (demo) {
+    const snippet = evt.detail.host.shadowRoot.querySelector(demoId);
+    const sdRenderer = snippet.shadowRoot.querySelector('vaadin-demo-shadow-dom-renderer');
+    if (sdRenderer) {
       window.removeEventListener('VaadinDemoReady', listenerFunction);
       emitted.push(demoId);
-      callback(demo);
+      callback(sdRenderer.shadowRoot);
     }
   };
 


### PR DESCRIPTION
The `window.addDemoReadyListener('#demo-id', function(document) {}` code in demo snippets stopped working after merging https://github.com/vaadin/vaadin-demo-helpers/pull/34. This commit fixes the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-demo-helpers/41)
<!-- Reviewable:end -->
