### PR TITLE
Passing template content to VaadinDemoReady listener

### DIFF
--- a/vaadin-demo-ready-event-emitter.html
+++ b/vaadin-demo-ready-event-emitter.html
@@ -11,7 +11,7 @@
       if (sdRenderer) {
         window.removeEventListener('VaadinDemoReady', listenerFunction);
         emitted.push(demoId);
-        callback(sdRenderer.shadowRoot);
+        callback(sdRenderer.shadowRoot, snippet.querySelector('template').content);
       }
     };
 


### PR DESCRIPTION
For `<vaadin-cookie-consent>` I have the following demo:
```html
<style>
  div.cc-window.cc-banner {
    background: rgb(136, 212, 254);
  }

  .cc-window .cc-dismiss {
    background: rgb(255, 81, 0);
  }

  .cc-window {
    font-size: 24px;
  }

  .cc-window .cc-message {
    color: rgb(0, 0, 255);
  }

  div.cc-window .cc-message a.cc-link {
    color: rgb(255, 81, 0);
  }
</style>
<vaadin-button>Show consent popup</vaadin-button>
<vaadin-cookie-consent></vaadin-cookie-consent>
```

I need to be able to access the style tag and copy it's contents during the initialization of the demo. This pull request allows this by passing the template content as a second parameter to the VaadinDemoReady listener.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-demo-helpers/44)
<!-- Reviewable:end -->
