### PR TITLE
Preserve vaadin-demo-ready-event-emitter.js upon magi P3 conversion

### DIFF
--- a/vaadin-demo-snippet.html
+++ b/vaadin-demo-snippet.html
@@ -8,7 +8,13 @@
 <link rel="import" href="vaadin-demo-shadow-dom-renderer.html">
 <link rel="import" href="vaadin-demo-iframe-renderer.html">
 
+<!-- MAGI REMOVE START -->
 <script src="vaadin-demo-ready-event-emitter.js"></script>
+<!-- MAGI REMOVE END -->
+
+<!-- MAGI ADD START
+<script src="vaadin-demo-ready-event-emitter.js" type="module"></script>
+MAGI ADD END -->
 
 <dom-module id="vaadin-demo-snippet-default-theme">
   <template>


### PR DESCRIPTION
Fixes #46 

`polyme-modulizer` eagerly incorporates the normal scripts where possible (as it is only imported in one file) but leaves scripts with `type="module"` as they are, hence this workaround helps.