### PR TITLE
Fix dev mode recognition when serving Polymer 3 components

### DIFF
--- a/vaadin-component-demo.html
+++ b/vaadin-component-demo.html
@@ -167,7 +167,7 @@
 
       _isDevMode(baseHref) {
         // FIXME: find a better way to detect when demo is running in flow
-        return /^cdn|github\.io|appspot\.com$/.test(location.hostname) || /\/components\/[a-z\-]+\/demo/.test(baseHref);
+        return /^cdn|github\.io|appspot\.com$/.test(location.hostname) || /\/components\/(@vaadin\/)?[a-z\-]+\/demo/.test(baseHref);
       }
 
       // Use hash fragment for navigation if we are using polyserve URL


### PR DESCRIPTION
Tweak RegExp to also enable hash based navigation for URLs produced by `polymer-serve --npm`:

```
http://127.0.0.1:8081/components/@vaadin/vaadin-checkbox/
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-demo-helpers/48)
<!-- Reviewable:end -->
