### PR TITLE
Add ignore-ie attribute for demo-snippet

### DIFF
--- a/vaadin-demo-snippet.html
+++ b/vaadin-demo-snippet.html
@@ -259,6 +259,18 @@ MAGI ADD END -->
 
       ready() {
         super.ready();
+
+        if (this.hasAttribute('ignore-ie') && !!navigator.userAgent.match(/Trident/)) {
+          let node = this.previousSibling;
+          while (!(node instanceof VaadinDemoSnippet)) {
+            let drop = node;
+            node = node.previousSibling;
+            drop.parentNode.removeChild(drop);
+          }
+          this.parentNode.removeChild(this);
+          return;
+        }
+
         Vaadin.LightDomHelper.querySelectorAsync('template', this)
           .then(template => {
             try {


### PR DESCRIPTION
Connected to vaadin/components-team-tasks#389

This way we ensure scripts containing ES6 do not run in IE11, so no `Syntax error` in the console.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-demo-helpers/55)
<!-- Reviewable:end -->
