### PR TITLE
fix(navigation): enable full page load for links to parent paths (..)

### DIFF
--- a/vaadin-component-demo.html
+++ b/vaadin-component-demo.html
@@ -74,7 +74,7 @@
       }
     </style>
 
-    <app-location id="appLocation" route="{{route}}" use-hash-as-path="[[devMode]]"></app-location>
+    <app-location id="appLocation" route="{{route}}" use-hash-as-path="[[devMode]]" url-space-regex="[[urlSpaceRegex]]"></app-location>
     <app-route id="appRoute" route="{{route}}" pattern="[[routePattern]]:page" data="{{routeData}}"></app-route>
 
     <vaadin-tabs selected="{{selectedPageIndex}}">
@@ -108,6 +108,8 @@
           srcBaseHref: String,
           _demoConfig: Object,
           routeData: Object,
+          // Navigation url scope regex
+          urlSpaceRegex: String,
           devMode: {
             type: Boolean,
             computed: '_isDevMode(baseHref)'
@@ -145,6 +147,9 @@
         super.ready();
         if (!this.srcBaseHref) {
           this.srcBaseHref = this.baseHref;
+        }
+        if (!this.urlSpaceRegex) {
+          this.urlSpaceRegex = this.baseHref.replace(/\//g, '\\/');
         }
       }
 


### PR DESCRIPTION
Connected to vaadin/vaadin-router#269

When `<a href="..">` is clicked, it is expected to go with full page load
instead of demo fetching, since the target path is not a demo page.

This allows for linking the API docs from demos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-demo-helpers/56)
<!-- Reviewable:end -->
