### PR TITLE
chore(package): update vaadin-tabs to 3.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "prism-element": "PolymerElements/prism-highlighter#^2.0.1",
     "app-route": "PolymerElements/app-route#^2.0.2",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.0",
-    "vaadin-tabs": "vaadin/vaadin-tabs#^2.0.0"
+    "vaadin-tabs": "vaadin/vaadin-tabs#^3.0.0"
   },
   "devDependencies": {
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.1.1",


### PR DESCRIPTION
Currently, the following error is thrown in the console of `vaadin-tabs` demos here
https://cdn.vaadin.com/vaadin-tabs/3.0.0/

```console
Uncaught DOMException: Failed to execute 'define' on 'CustomElementRegistry': this name has already been used with this registry
    at https://cdn.vaadin.com/vaadin-tabs/3.0.0/src/vaadin-tab.html:73:22
    at https://cdn.vaadin.com/vaadin-tabs/3.0.0/src/vaadin-tab.html:80:7
```

We should update vaadin-tabs here and then bump the **major** version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-demo-helpers/66)
<!-- Reviewable:end -->
