### PR TITLE
Revert tabs implementation

### DIFF
--- a/vaadin-component-demo.html
+++ b/vaadin-component-demo.html
@@ -3,8 +3,6 @@
 <link rel="import" href="../app-route/app-location.html">
 <link rel="import" href="../app-route/app-route.html">
 <link rel="import" href="vaadin-fetch-demo-data-mixin.html">
-<link rel="import" href="../vaadin-tabs/vaadin-tabs.html">
-<link rel="import" href="../vaadin-tabs/vaadin-tab.html">
 
 <dom-module id="vaadin-component-demo-shared-styles">
   <template>
@@ -67,21 +65,56 @@
         margin-right: auto;
       }
 
-      vaadin-tab a {
+      nav {
+        box-shadow: inset 0 -1px 0 0 rgba(0, 0, 0, 0.1);
+        margin-bottom: 3em;
+        overflow: auto;
+        -webkit-overflow-scrolling: touch;
+      }
+
+      nav ul {
+        padding: 0;
+        margin: 0;
+        display: flex;
+      }
+
+      nav ul li {
+        list-style: none;
+        flex: none;
+      }
+
+      nav a {
+        display: inline-block;
+        padding: 1em;
+      }
+
+      nav a {
+        color: #829191;
         text-decoration: none;
-        outline: none;
-        color: inherit;
+        border-bottom: 2px solid transparent;
+      }
+
+      nav a:focus,
+      nav a:hover,
+      nav a[active] {
+        color: #2d3033;
+      }
+
+      nav a[active] {
+        border-color: #44d62c;
       }
     </style>
 
     <app-location id="appLocation" route="{{route}}" use-hash-as-path="[[devMode]]" url-space-regex="[[urlSpaceRegex]]"></app-location>
     <app-route id="appRoute" route="{{route}}" pattern="[[routePattern]]:page" data="{{routeData}}"></app-route>
 
-    <vaadin-tabs selected="{{selectedPageIndex}}">
-      <template is="dom-repeat" items="[[_demoConfig.pages]]" as="page" id="navigationRepeat">
-        <vaadin-tab><a href="[[linkBase]][[page.url]]" tabindex="-1">[[page.name]]</a></vaadin-tab>
-      </template>
-    </vaadin-tabs>
+    <nav id="nav">
+      <ul>
+        <template is="dom-repeat" items="[[_demoConfig.pages]]" as="page" id="navigationRepeat">
+          <li><a href$="[[linkBase]][[page.url]]" name$="[[page.url]]">[[page.name]]</a></li>
+        </template>
+      </ul>
+    </nav>
 
     <div id="demo"></div>
   </template>
@@ -124,9 +157,13 @@
             type: String,
             computed: '_getRoutePattern(devMode, linkBase)'
           },
-          selectedPageIndex: {
-            type: Number,
-            observer: '_pageIndexChanged'
+          selectedPage: {
+            type: String,
+            observer: '_pageChanged'
+          },
+          navigationRepeatReady: {
+            type: Boolean,
+            value: false
           }
         };
       }
@@ -153,17 +190,29 @@
         if (!this.urlSpaceRegex) {
           this.urlSpaceRegex = this.baseHref.replace(/\//g, '\\/');
         }
+        this.$.navigationRepeat.addEventListener('dom-change', () => {
+          this.navigationRepeatReady = true;
+        });
       }
 
       static get observers() {
         return [
-          '_routePageChanged(routeData.page)',
+          '_routePageChanged(routeData.page, navigationRepeatReady)',
         ];
       }
 
-      _routePageChanged(page) {
-        if (this._demoConfig && this._demoConfig.pages && page) {
-          this._setSelectedPageIndexFromPages(this._demoConfig.pages, page);
+      _routePageChanged(page, navigationRepeatReady) {
+        if (!page) {
+          return;
+        }
+
+        this.selectedPage = page;
+
+        if (navigationRepeatReady) {
+          Array.from(this.$.nav.querySelectorAll('a')).forEach(e => e.removeAttribute('active'));
+          const activeLink = this.$.nav.querySelector('a[name="' + page + '"]');
+          activeLink.setAttribute('active', '');
+          activeLink.scrollIntoView();
         }
       }
 
@@ -172,13 +221,12 @@
           this.fetchJSON(configSrc)
             .then(json => {
               this._demoConfig = json;
-              this.selectedPageIndex = undefined;
+              this.selectedPage = undefined;
               if (json.pages && json.pages.length > 0) {
-                if (this.routeData.page) {
-                  this._setSelectedPageIndexFromPages(json.pages, this.routeData.page);
-                } else {
-                  // Select first page by default
-                  this.selectedPageIndex = 0;
+                // Select first page by default and update url
+                this.selectedPage = this.routeData.page || json.pages[0].url;
+                if (!this.routeData.page) {
+                  this.$.appLocation.set('path', (this.devMode ? '' : this.linkBase) + this.selectedPage);
                 }
               }
             })
@@ -188,20 +236,20 @@
         }
       }
 
-      _pageIndexChanged(selectedPageIndex) {
-        if (selectedPageIndex === undefined || !this._demoConfig) {
+      _pageChanged(selectedPage) {
+        if (!selectedPage || !this._demoConfig) {
           return;
         }
 
         let page;
-        if (selectedPageIndex) {
-          page = this._demoConfig.pages[selectedPageIndex];
+        if (selectedPage) {
+          page = this._demoConfig.pages.filter(page => page.url === selectedPage)[0];
         } else {
           page = this._demoConfig.pages[0];
         }
 
         if (!page) {
-          console.error(`ERROR: Could not find demo page with index: '${selectedPageIndex}.'`);
+          console.error(`ERROR: Could not find demo page '${selectedPage}.'`);
           return;
         }
 
@@ -210,28 +258,14 @@
             this._showDemo(page.url);
           })
           .catch(err => {
-            console.error(`ERROR: Failed to load demo page for index '${selectedPageIndex}'`, err);
+            console.error(`ERROR: Failed to load demo page for '${selectedPage}'`, err);
           });
-
-        this.$.appLocation.set('path', (this.devMode ? '' : this.linkBase) + page.url);
       }
 
       _showDemo(tagName) {
         const element = document.createElement(tagName);
         this.$.demo.innerHTML = '';
         this.$.demo.appendChild(element);
-      }
-
-      _setSelectedPageIndexFromPages(pages, selectedPage) {
-        let index;
-        // Array#findIndex is not supported in IE11
-        pages.some((configPage, i) => {
-          if (configPage.url == selectedPage) {
-            index = i;
-            return true;
-          }
-        });
-        this.selectedPageIndex = index || 0;
       }
     }
     window.customElements.define(VaadinComponentDemo.is, VaadinComponentDemo);


### PR DESCRIPTION
Fixes #69 
Reverting https://github.com/vaadin/vaadin-demo-helpers/pull/40 in order to avoid dependency conflicts.
`demo-helpers` with tabs are intended to be used only on CDN which is not anymore official demo for our components, so we are safe to revert this change.